### PR TITLE
query_by_similarity_IMGVR.R and query_by_similarity_cli.R scripts added

### DIFF
--- a/embeddings/query_by_similarity_IMGVR.R
+++ b/embeddings/query_by_similarity_IMGVR.R
@@ -1,0 +1,137 @@
+#!/usr/bin/env Rscript
+
+rm(list=ls())
+setwd("~/Projects/KE")
+
+library("pheatmap")
+library("amap")
+library("gplots")
+library("RColorBrewer")
+library("cluster")
+library("grid")
+library("tcR")
+
+setwd("~/Projects/KE")
+
+data <- read.csv("/global/cfs/cdirs/kbase/ke_prototype/embeddings/SkipGram_embedding_IMGVR_merged_final_embedding.tsv", sep="\t", header=TRUE, row.names=1)
+head(data)
+dim(data)
+node_data <- read.csv("/global/cfs/cdirs/kbase/ke_prototype/graphs/IMGVR/IMGVR_merged_final_KGX_nodes.tsv", sep="\t",header=T)
+dim(node_data)
+head(node_data)
+
+#GOLD:bulk_soil
+
+grep("GOLD:anaerobic$", node_data$id)
+index <- grep("GOLD:anaerobic$", node_data$id)
+node_data[index,]
+
+#row.names(data) <- node_data$V2
+#write.table(data, file="../IMGVR/SkipGram_embedding_IMGVR_extra_wids.tsv",sep="\t", row.names = F)
+
+
+#row.names(data)[index]
+
+#Alkaline = 3
+
+
+###
+###
+###
+cosine_simfast <- function(a,b) {
+  crossprod(a,b)/sqrt(crossprod(a)*crossprod(b))
+}
+
+###for matrix
+cos_sim_mat <- function(x) {crossprod(x)/(sqrt(tcrossprod(colSums(x^2))))}
+
+angle <- function(x,y){
+  dot.prod <- x%*%y
+  norm.x <- norm(x,type="2")
+  norm.y <- norm(y,type="2")
+  theta <- acos(dot.prod / (norm.x * norm.y))
+  as.numeric(theta)
+}
+
+run_search <- function(query, query_data, data, distance="cosine", cutoff=0.9, hits = 1000) {
+
+  qindex <- which(row.names(query_data) == query)
+
+  print(as.numeric(query_data[qindex,]))
+
+  print(paste("qindex", qindex))
+  if(length(qindex) == 0) {
+    return("query not found")
+  }
+
+  print(paste(query, qindex))
+
+  if(distance == "euclidean" && cutoff == 0.9) {
+    print("resetting distance cutoff for Euclidean to 0.1")
+    cutoff = 0.1
+  }
+  start_time <- Sys.time()
+  total <- 0
+  all <- c()
+
+  output <- c()
+  labels <- c()
+  for(j in 1:dim(data)[1]) {
+
+    if(j != qindex) {
+      if(distance == "cosine") {
+        #dist <- angle(as.numeric(data[qindex,]), as.numeric(data[j,]))
+
+        #print(as.numeric(data[j,]))
+        dist <- cosine_simfast(as.numeric(query_data[qindex,]), as.numeric(data[j,]))
+        #print(paste("dist cos", dist))
+        if(dist > cutoff) {
+          #print(row.names(datahuman)[j])
+          output <- c(output, dist)
+          addval <- row.names(data)[j]#paste(query, row.names(data)[j], sep="\t")
+          labels <- c(labels, addval)
+          total <- total + 1
+        }
+      }
+      else if(distance == "euclidean") {
+        dist <- dist(rbind(as.numeric(query_data[qindex,]), as.numeric(data[j,])))
+        if(dist < cutoff) {
+          #print(row.names(datahuman)[j])
+          #print(paste("dist euc", dist))
+          output <- c(output, dist)
+          addval <-  row.names(data)[j]#paste(query,, sep="\t")
+          labels <- c(labels, addval)
+          total <- total +1
+        }
+      }
+
+      all <- c(all, as.numeric(dist))
+
+    }
+  }
+
+  names(output) <- labels
+  if(length(output) >0) {
+    #sort and take top hits
+    sorted_top <- sort(abs(output), decreasing=TRUE)[1:min(length(output), hits)]
+    #print(sorted_top)
+    outfile <- paste(distance,"__",query,"_top",hits,"_cutoff",cutoff,".txt",sep="")
+
+    print(paste("saving ", dim(sorted_top), outfile))
+    write.table(sorted_top, outfile, sep="\t", col.names=F)
+  }
+  else {
+    print("nothing")
+  }
+
+  end_time <- Sys.time()
+  print(paste("time", end_time - start_time))
+}
+
+queries <- index[1] #index
+print(row.names(data)[queries])
+for(i in 1:length(queries)) {
+  print(paste("running", row.names(data)[queries[i]]))
+  run_search( row.names(data)[queries[i]], data[queries[i],], data, distance="cosine", cutoff=0.85)
+}
+

--- a/embeddings/query_by_similarity_cli.R
+++ b/embeddings/query_by_similarity_cli.R
@@ -1,0 +1,219 @@
+#!/usr/bin/env Rscript
+
+rm(list=ls())
+
+# load argparse first because needed to check for input files
+library("argparse")
+
+# create parser object
+parser <- ArgumentParser()
+
+parser$add_argument("-e", "--embeddings", help="Indicate an embeddings file", default="")
+parser$add_argument("-n", "--nodes", help="Indicate a nodes file", default="")
+parser$add_argument("-s", "--search_string", help="Search term (e.g. GOLD:anaerobic, GOLD:bulk_soil, ...)", default="")
+parser$add_argument("-w", "--working_directory", help="Indicate working directory", default=getwd())
+parser$add_argument("-d", "--distance", help="Indicate distance method [cosine|euclidean] (default: cosine)", default="cosine")
+parser$add_argument("-c", "--cutoff", help="Indicate cutoff value (default: 0.85)", default=0.9)
+parser$add_argument("-z", "--num_hits", help="Indicate number of hits to retain and export (default: 1000)", default=1000)
+
+# get command line options, if help option encountered print help and exit,
+# otherwise if options not found on command line then set defaults, 
+args <- parser$parse_args()
+
+
+# print some progress messages if variables not entered correctly
+if ( args$embeddings == "" ) { 
+    write("Error: bad link to embeddings file. Exiting.\n", stderr())
+    quit(status=1)
+}
+
+if ( args$nodes == "" ) { 
+    write("Error: bad link to nodes file. Exiting.\n", stderr()) 
+    quit(status=1)
+}
+
+if ( args$search_string == "" ) { 
+    write("Error: input a search string. Exiting.\n", stderr()) 
+    quit(status=1)
+}
+
+if (( !args$distance == "cosine" ) & ( !args$distance == "euclidean" )) { 
+    write("Error: incorrect distance method selected. Exiting.\n", stderr()) 
+    quit(status=1)
+}
+
+if (( args$cutoff >= 1 ) || ( args$cutoff <= 0 )) { 
+    write("Error: incorrect cutoff selected. Exiting.\n", stderr()) 
+    quit(status=1)
+}
+
+# not sure why this variable assertion isn't working, will need to address later
+# if ( args$num_hits <= 0 || all.equal(args$num_hits, as.integer(args$num_hits)) != TRUE ) { 
+#     write("Error: incorrect number of hits selected. Exiting.\n", stderr()) 
+#     quit(status=1)
+# }
+
+# load non-argparse libraries only after checking for required input files
+library("pheatmap")
+library("amap")
+library("gplots")
+library("RColorBrewer")
+library("cluster")
+library("grid")
+library("tcR")
+
+embedding_file <- args$embeddings
+nodes_file <- args$nodes
+search_string <- args$search_string
+#distance <- "cosine"
+#cutoff <- 0.9
+#hits <- 1000
+distance <- args$distance
+cutoff <- args$cutoff
+hits <- args$num_hits
+
+setwd(args$working_directory)
+
+#embedding_file <- "/global/cfs/cdirs/kbase/ke_prototype/embeddings/SkipGram_embedding_IMGVR_merged_final_embedding.tsv"
+#data <- read.csv("/global/cfs/cdirs/kbase/ke_prototype/embeddings/SkipGram_embedding_IMGVR_merged_final_embedding.tsv", sep="\t", header=TRUE, row.names=1)
+data <- read.csv(embedding_file, sep="\t", header=TRUE, row.names=1)
+head(data)
+dim(data)
+
+#nodes_file <- "/global/cfs/cdirs/kbase/ke_prototype/graphs/IMGVR/IMGVR_merged_final_KGX_nodes.tsv"
+#node_data <- read.csv("/global/cfs/cdirs/kbase/ke_prototype/graphs/IMGVR/IMGVR_merged_final_KGX_nodes.tsv", sep="\t",header=T)
+node_data <- read.csv(nodes_file, sep="\t",header=T)
+dim(node_data)
+head(node_data)
+
+#search_string<-"GOLD:bulk_soil"
+search_string_input<-paste0(search_string,'$')
+
+#grep("GOLD:anaerobic$", node_data$id)
+grep(search_string_input, node_data$id)
+#index <- grep("GOLD:anaerobic$", node_data$id)
+index <- grep(search_string_input, node_data$id)
+
+node_data[index,]
+
+#row.names(data) <- node_data$V2
+#write.table(data, file="../IMGVR/SkipGram_embedding_IMGVR_extra_wids.tsv",sep="\t", row.names = F)
+
+#row.names(data)[index]
+#Alkaline = 3
+
+###
+###
+###
+cosine_simfast <- function(a,b) {
+  crossprod(a,b)/sqrt(crossprod(a)*crossprod(b))
+}
+
+###for matrix
+cos_sim_mat <- function(x) {crossprod(x)/(sqrt(tcrossprod(colSums(x^2))))}
+
+angle <- function(x,y){
+  dot.prod <- x%*%y
+  norm.x <- norm(x,type="2")
+  norm.y <- norm(y,type="2")
+  theta <- acos(dot.prod / (norm.x * norm.y))
+  as.numeric(theta)
+}
+
+run_search <- function(query, query_data, data, distance, cutoff, hits) {
+
+  qindex <- which(row.names(query_data) == query)
+
+  #print(as.numeric(query_data[qindex,]))
+
+  print(paste("qindex", qindex))
+  if(length(qindex) == 0) {
+    return("query not found")
+  }
+
+  #print(paste(query, qindex))
+
+  if(distance == "euclidean" && cutoff == 0.9) {
+    print("resetting distance cutoff for Euclidean to 0.1")
+    cutoff = 0.1
+  }
+  start_time <- Sys.time()
+  total <- 0
+  all <- c()
+
+  output <- c()
+  labels <- c()
+  for(j in 1:dim(data)[1]) {
+
+    if(j != qindex) {
+      if(distance == "cosine") {
+        #dist <- angle(as.numeric(data[qindex,]), as.numeric(data[j,]))
+
+        #print(as.numeric(data[j,]))
+        dist <- cosine_simfast(as.numeric(query_data[qindex,]), as.numeric(data[j,]))
+        #print(paste("dist cos", dist))
+        if(dist > cutoff) {
+          #print(row.names(datahuman)[j])
+          output <- c(output, dist)
+          addval <- row.names(data)[j]#paste(query, row.names(data)[j], sep="\t")
+          labels <- c(labels, addval)
+          total <- total + 1
+        }
+      }
+      else if(distance == "euclidean") {
+        dist <- dist(rbind(as.numeric(query_data[qindex,]), as.numeric(data[j,])))
+        if(dist < cutoff) {
+          #print(row.names(datahuman)[j])
+          #print(paste("dist euc", dist))
+          output <- c(output, dist)
+          addval <-  row.names(data)[j]#paste(query,, sep="\t")
+          labels <- c(labels, addval)
+          total <- total +1
+        }
+      }
+
+      all <- c(all, as.numeric(dist))
+
+    }
+  }
+
+  names(output) <- labels
+  if(length(output) >0) {
+    #sort and take top hits
+    sorted_top <- sort(abs(output), decreasing=TRUE)[1:min(length(output), hits)]
+    print("sorted_top")
+    print(head(sorted_top))
+
+    output_data<-data.frame(V1=rownames(data.frame(sorted_top)),V2=as.vector(sorted_top))
+
+    # need next line only if output file name cannot have colon ':' symbol
+    #query_output_name<-gsub(":", "_", query_output_name)
+    query_output_name<-node_data[as.integer(output_data$V1[1])+1,]$id
+
+    for(i in 1:nrow(output_data)) {
+      output_data$V1[i]<-node_data[as.integer(output_data$V1[i])+1,]$id
+    }
+
+    outfile <- paste(distance,"__",query_output_name,"_top",hits,"_cutoff",cutoff,".txt",sep="")
+
+    print(paste("saving ", dim(sorted_top), outfile))
+
+    #write.table(sorted_top, outfile, sep="\t", col.names=F)
+    write.table(output_data, outfile, sep="\t", col.names=F, row.names=F, quote=F)
+  }
+  else {
+    print("nothing")
+  }
+
+  end_time <- Sys.time()
+  print(paste("time", end_time - start_time))
+}
+
+queries <- index[1] #index
+print(row.names(data)[queries])
+for(i in 1:length(queries)) {
+  print(paste("running", row.names(data)[queries[i]]))
+  #run_search( row.names(data)[queries[i]], data[queries[i],], data, distance="cosine", cutoff=0.85, hits = 1000)
+  run_search( row.names(data)[queries[i]], data[queries[i],], data, distance, cutoff, hits)
+}
+

--- a/embeddings/query_by_similarity_cli.R
+++ b/embeddings/query_by_similarity_cli.R
@@ -120,7 +120,7 @@ angle <- function(x,y){
   as.numeric(theta)
 }
 
-run_search <- function(query, query_data, data, distance, cutoff, hits) {
+run_search <- function(query, query_data, data, distance, cutoff, hits, search_string) {
 
   qindex <- which(row.names(query_data) == query)
 
@@ -188,7 +188,7 @@ run_search <- function(query, query_data, data, distance, cutoff, hits) {
 
     # need next line only if output file name cannot have colon ':' symbol
     #query_output_name<-gsub(":", "_", query_output_name)
-    query_output_name<-node_data[as.integer(output_data$V1[1])+1,]$id
+    query_output_name<-search_string
 
     for(i in 1:nrow(output_data)) {
       output_data$V1[i]<-node_data[as.integer(output_data$V1[i])+1,]$id
@@ -214,6 +214,6 @@ print(row.names(data)[queries])
 for(i in 1:length(queries)) {
   print(paste("running", row.names(data)[queries[i]]))
   #run_search( row.names(data)[queries[i]], data[queries[i],], data, distance="cosine", cutoff=0.85, hits = 1000)
-  run_search( row.names(data)[queries[i]], data[queries[i],], data, distance, cutoff, hits)
+  run_search( row.names(data)[queries[i]], data[queries[i],], data, distance, cutoff, hits, search_string)
 }
 


### PR DESCRIPTION
query_by_similarity_IMGVR.R adapted first, then query_by_similarity_cli.R to provide command line flexibility. 

example command:
query_by_similarity_cli.R --embeddings /global/cfs/cdirs/kbase/ke_prototype/embeddings/SkipGram_embedding_IMGVR_merged_final_embedding.tsv --nodes /global/cfs/cdirs/kbase/ke_prototype/graphs/IMGVR/IMGVR_merged_final_KGX_nodes.tsv --search_string ko:K00007 --distance cosine --cutoff 0.9 --num_hits 1000